### PR TITLE
v30: Fix `yarn`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -226,6 +226,7 @@ RUN groupadd --gid=1000 code \
 # Copy node utilities first, because the bin directory include symlinks that we want to preserve.
 COPY --from=node /usr/local/man/man1/node.1 /usr/local/man/man1/
 COPY --from=node /usr/local/include/node /usr/local/include/node
+COPY --from=node /opt/ /opt/
 COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=node /usr/local/bin/ /usr/local/bin/
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -169,8 +169,10 @@ ARG ACTIONLINT_VERSION=v1.6.15
 RUN url="https://github.com/rhysd/actionlint/releases/download/${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION#v}_linux_amd64.tar.gz" ; \
     scurl "$url" | tar xzvf - -C /usr/local/bin actionlint
 
-FROM docker.io/rust:1.63.0-slim as json5-to-json
-RUN cargo install json5-to-json
+FROM base as j5j
+ARG J5J_VERSION=v0.2.0
+RUN url="https://github.com/olix0r/j5j/releases/download/${J5J_VERSION}/j5j-${J5J_VERSION}-x86_64-unknown-linux-musl.tar.gz" ; \
+    scurl "$url" | tar zvxf - -C /usr/local/bin j5j
 
 FROM docker.io/node:16-bullseye-slim as node
 ARG MARKDOWNLINT_VERSION=0.5.1
@@ -183,7 +185,7 @@ RUN npm install "markdownlint-cli2@${MARKDOWNLINT_VERSION}" --global
 FROM base as tools
 COPY --from=actionlint /usr/local/bin/actionlint /usr/local/bin/
 COPY --from=checksec /usr/local/bin/checksec /usr/local/bin/che
-COPY --from=json5-to-json /usr/local/cargo/bin/json5-to-json /usr/local/bin/
+COPY --from=j5j /usr/local/bin/j5j /usr/local/bin/
 COPY --from=just /usr/local/bin/just /usr/local/bin/
 COPY --from=k8s /usr/local/bin/helm /usr/local/bin/
 COPY --from=k8s /usr/local/bin/helm-docs /usr/local/bin/

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -180,7 +180,7 @@ RUN npm install "markdownlint-cli2@${MARKDOWNLINT_VERSION}" --global
 
 FROM base as step
 RUN scurl -O https://dl.step.sm/gh-release/cli/docs-cli-install/v0.21.0/step-cli_0.21.0_amd64.deb \
-    && sudo dpkg -i step-cli_0.21.0_amd64.deb
+    && dpkg -i step-cli_0.21.0_amd64.deb
 
 ##
 ## Tools: Everything needed for a development environment, minus non-root settings.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -178,6 +178,10 @@ FROM docker.io/node:16-bullseye-slim as node
 ARG MARKDOWNLINT_VERSION=0.5.1
 RUN npm install "markdownlint-cli2@${MARKDOWNLINT_VERSION}" --global
 
+FROM base as step
+RUN scurl -O https://dl.step.sm/gh-release/cli/docs-cli-install/v0.21.0/step-cli_0.21.0_amd64.deb \
+    && sudo dpkg -i step-cli_0.21.0_amd64.deb
+
 ##
 ## Tools: Everything needed for a development environment, minus non-root settings.
 ##
@@ -194,6 +198,7 @@ COPY --from=k8s /usr/local/bin/kubectl /usr/local/bin/
 COPY --from=protoc /usr/local/bin/protoc /usr/local/bin/
 COPY --from=protoc /usr/local/include/google /usr/local/include/google
 COPY --from=shellcheck /usr/local/bin/shellcheck /usr/local/bin/
+COPY --from=step /usr/bin/step-cli /usr/local/bin/step
 COPY --from=yq /usr/local/bin/yq /usr/local/bin/
 COPY bin/action-dev-check /usr/local/bin/
 ENV PROTOC_NO_VENDOR=1

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -63,8 +63,10 @@ RUN url="https://github.com/xd009642/tarpaulin/releases/download/${CARGO_TARPAUL
 
 FROM docker.io/rust:1.63.0-slim-bullseye as rust
 RUN rustup component add clippy rustfmt
+RUN rustup target add x86_64-unknown-linux-musl
 RUN apt update && apt upgrade -y --autoremove \
     && apt install -y \
+        binutils-x86-64-linux-gnu \
         clang \
         cmake \
         curl \
@@ -72,6 +74,7 @@ RUN apt update && apt upgrade -y --autoremove \
         jo \
         jq \
         libssl-dev \
+        musl-tools \
         pkg-config \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=cargo-action-fmt /usr/local/bin/cargo-action-fmt /usr/local/cargo/bin/
@@ -202,6 +205,7 @@ ENV PROTOC_INCLUDE=/usr/local/include
 FROM docker.io/debian:bullseye as runtime
 RUN apt update && apt upgrade -y --autoremove \
     && apt install -y \
+        binutils-x86-64-linux-gnu \
         clang curl \
         cmake \
         file \
@@ -210,6 +214,7 @@ RUN apt update && apt upgrade -y --autoremove \
         libssl-dev \
         locales \
         lsb-release \
+        musl-tools \
         pkg-config \
         sudo \
         time \

--- a/.devcontainer/bin/action-dev-check
+++ b/.devcontainer/bin/action-dev-check
@@ -10,13 +10,13 @@ IMAGE=$(j5j .devcontainer/devcontainer.json |jq -r '.image')
 check_image() {
     if [ "$1" != "$IMAGE" ]; then
         # Report all line numbers with the unexpected image.
-        for n in $(grep -nF "$1" "$2" | cut -d: -f1) ; do
+        while IFS= read -r n ; do
             if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
                 echo "::error file=${2},line=${n}::Expected image '${IMAGE}'; found '${1}'">&2
             else
                 echo "${2}:${n}: Expected image '${IMAGE}'; found '${1}'" >&2
             fi
-        done
+        done < <(grep -nF "$1" "$2" | cut -d: -f1)
         return 1
     fi
 }
@@ -40,14 +40,13 @@ fi
 # Check actions for devcontainer images
 if [ -d .github/actions ]; then
     while IFS= read -r f ; do
-        for i in $(awk 'toupper($1) ~ "FROM" { print $2 }' "$f" \
-                    | sed -Ene 's,(ghcr\.io/linkerd/dev:v[0-9]+).*,\1,p')
-        do
+        while IFS= read -r i ; do
             if ! check_image "$i" "$f" ; then
                 EX=$((EX+1))
                 break
             fi
-        done
+        done < <(awk 'toupper($1) ~ "FROM" { print $2 }' "$f" \
+                    | sed -Ene 's,(ghcr\.io/linkerd/dev:v[0-9]+).*,\1,p')
     done < <(find .github/actions -name Dockerfile\*)
 fi
 

--- a/.devcontainer/bin/action-dev-check
+++ b/.devcontainer/bin/action-dev-check
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-IMAGE=$(json5-to-json <.devcontainer/devcontainer.json |jq -r '.image')
+IMAGE=$(j5j .devcontainer/devcontainer.json |jq -r '.image')
 
 check_image() {
     if [ "$1" != "$IMAGE" ]; then

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,19 @@
 {
     "name": "linkerd-dev",
-    "image": "ghcr.io/linkerd/dev:v29",
+    "image": "ghcr.io/linkerd/dev:v30",
     "extensions": [
         "DavidAnson.vscode-markdownlint",
-        "golang.go",
+        // "golang.go",
         "kokakiwi.vscode-just",
-        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        // "ms-kubernetes-tools.vscode-kubernetes-tools",
         "NathanRidley.autotrim",
-        "rust-lang.rust-analyzer",
+        //"rust-lang.rust-analyzer",
         "samverschueren.final-newline",
         "tamasfe.even-better-toml",
-        "zxh404.vscode-proto3"
+        // "zxh404.vscode-proto3"
     ],
     "settings": {
-        "go.lintTool": "golangci-lint"
+        // "go.lintTool": "golangci-lint"
     },
     "runArgs": [
         "--init",
@@ -21,10 +21,7 @@
         "--memory=12g",
         "--memory-swap=12g",
         // Use the host network so we can access k3d, etc.
-        "--net=host",
-        // For lldb
-        "--cap-add=SYS_PTRACE",
-        "--security-opt=seccomp=unconfined"
+        "--net=host"
     ],
     "overrideCommand": false,
     "remoteUser": "code",

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,14 +14,14 @@ jobs:
   actionlint:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
-    container: ghcr.io/linkerd/dev:v29-tools
+    container: ghcr.io/linkerd/dev:v30-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just action-lint
 
   devcontainer-versions:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v29-tools
+    container: ghcr.io/linkerd/dev:v30-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just action-dev-check

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -11,24 +11,27 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  devcontainer-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: docker build .devcontainer
 
-  devcontainer-image:
+  devcontainer-pull:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update
-          sudo apt-get -y --no-install-recommends install jq
-      - run: |
-          # Strip jsonc comments because `jq` doesn't support them.
-          image=$(sed -E '/^\s*\/\/.*/d' .devcontainer/devcontainer.json |jq -Mr .image)
-          line=$(grep -nF '"image"' .devcontainer/devcontainer.json |cut -d':' -f1 |head -n1)
+      - name: Install j5j
+        uses: extractions/setup-crate@504d95f4c6cbfa8975d1094bbf5a42965e46569a
+        with:
+          owner: olix0r
+          name: j5j
+      - name: Pull image
+        shell: bash
+        run: |
+          set -eu
+          image=$(j5j .devcontainer/devcontainer.json |jq -r .image)
+          line=$(grep -nF '"image":' .devcontainer/devcontainer.json |cut -d':' -f1 |head -n1)
           if [ "$image" == "null" ]; then
             echo "::error file=.devcontainer/devcontainer.json,line=$line::Missing image"
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+!.devcontainer

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 # See https://just.systems/man/en
 
-lint: md-lint sh-lint
+lint: md-lint sh-lint action-lint action-dev-check
 
 ##
 ## Devcontainer
@@ -51,7 +51,13 @@ md-lint:
     markdownlint-cli2 '**/*.md' '!**/node_modules' '!**/target'
 
 sh-lint:
-    bin/shellcheck-all
+    #!/usr/bin/env bash
+    set -euo pipefail
+    files=$(while IFS= read -r f ; do
+        if [ "$(file -b --mime-type "$f")" = text/x-shellscript ]; then echo "$f"; fi
+    done < <(find .devcontainer -type f ! \( -path ./.git/\* -or -path \*/target/\* \)) | xargs)
+    echo "shellcheck $files" >&2
+    shellcheck $files
 
 ##
 ## Git


### PR DESCRIPTION
`yarn` is installed into `/opt`, but we didn't copy that directory into
the runtime devcontainer.

This change also removes rust and go extensions from this workspace
(because they're slow working in such a large repo).

Signed-off-by: Oliver Gould <ver@buoyant.io>