### PR TITLE
Update Rust to 1.72.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -281,7 +281,7 @@ ENV PROTOC_NO_VENDOR=1 \
     PROTOC_INCLUDE=/usr/local/include
 
 # A Rust build environment.
-FROM docker.io/rust:1.69.0-slim-bullseye as rust
+FROM docker.io/rust:1.72.1-slim-bullseye as rust
 RUN --mount=type=cache,from=apt-base,source=/etc/apt,target=/etc/apt,ro \
     --mount=type=cache,from=apt-base,source=/var/cache/apt,target=/var/cache/apt \
     --mount=type=cache,from=apt-base,source=/var/lib/apt/lists,target=/var/lib/apt/lists,ro \


### PR DESCRIPTION
This should help fix issues where some dependencies don't build on Rust versions <1.70.