### PR TITLE
dev: v42

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "linkerd-dev",
-    "image": "ghcr.io/linkerd/dev:v41",
+    "image": "ghcr.io/linkerd/dev:v42",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -53,6 +53,9 @@ jobs:
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - uses: ./actions/setup-tools
+      - run: |
+          cat "$K3S_IMAGES_JSON"
+          jq -r '.name + ":" + .channels["${{ matrix.channel }}"] + "@" + .digests[.channels["${{ matrix.channel }}"]]' "$K3S_IMAGES_JSON"
       - run: bin/just-k3d K3S_CHANNEL='${{ matrix.channel }}' create use
       - name: Check that server tag is ${{ matrix.tag }}
         run: |

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - uses: ./actions/setup-tools
-      - run: bin/just-k3d K3S_IMAGES_JSON=k3d-images.json K3S_CHANNEL='${{ matrix.channel }}' create use
+      - run: bin/just-k3d K3S_IMAGES_JSON=k3s-images.json K3S_CHANNEL='${{ matrix.channel }}' create use
       - name: Check that server tag is ${{ matrix.tag }}
         run: |
           tag=$(kubectl version --output=json | jq -r '.serverVersion.gitVersion | sub("\\+"; "-")')

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -53,10 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - uses: ./actions/setup-tools
-      - run: |
-          cat "$K3S_IMAGES_JSON"
-          jq -r '.name + ":" + .channels["${{ matrix.channel }}"] + "@" + .digests[.channels["${{ matrix.channel }}"]]' "$K3S_IMAGES_JSON"
-      - run: bin/just-k3d K3S_CHANNEL='${{ matrix.channel }}' create use
+      - run: bin/just-k3d K3S_IMAGES_JSON=k3d-images.json K3S_CHANNEL='${{ matrix.channel }}' create use
       - name: Check that server tag is ${{ matrix.tag }}
         run: |
           tag=$(kubectl version --output=json | jq -r '.serverVersion.gitVersion | sub("\\+"; "-")')

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@
 # should not be published. Instead, these layers should be used to provide
 # cached data to individual `RUN` commands.
 
-FROM docker.io/library/debian:bullseye-slim as apt-base
-RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' >>/etc/apt/sources.list
+FROM docker.io/library/debian:bookworm-slim as apt-base
+RUN echo 'deb http://deb.debian.org/debian bookworm-backports main' >>/etc/apt/sources.list
 RUN DEBIAN_FRONTEND=noninteractive apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip xz-utils
 COPY --link bin/scurl /usr/local/bin/
@@ -17,16 +17,16 @@ COPY --link bin/scurl /usr/local/bin/
 FROM apt-base as apt-node
 RUN apt-get install -y gnupg2
 ARG NODE_MAJOR=20
-RUN mkdir -p /etc/apt/keyrings && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN mkdir -p /etc/apt/keyrings && scurl https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install nodejs -y
 
 FROM apt-base as apt-llvm
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg2
-RUN curl --tlsv1.2 -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key |apt-key add -
-RUN ( echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main' \
-    && echo 'deb-src http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main' ) >> /etc/apt/sources.list
-RUN DEBIAN_FRONTEND=noninteractive apt-get update
+# RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg2
+# RUN curl --tlsv1.2 -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key |apt-key add -
+# RUN ( echo 'deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-14 main' \
+#     && echo 'deb-src http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-14 main' ) >> /etc/apt/sources.list
+# RUN DEBIAN_FRONTEND=noninteractive apt-get update
 
 ##
 ## Scripting tools
@@ -282,7 +282,7 @@ ENV PROTOC_NO_VENDOR=1 \
     PROTOC_INCLUDE=/usr/local/include
 
 # A Rust build environment.
-FROM docker.io/rust:1.73.0-slim-bullseye as rust
+FROM docker.io/rust:1.73.0-slim-bookworm as rust
 RUN --mount=type=cache,from=apt-base,source=/etc/apt,target=/etc/apt,ro \
     --mount=type=cache,from=apt-base,source=/var/cache/apt,target=/var/cache/apt \
     --mount=type=cache,from=apt-base,source=/var/lib/apt/lists,target=/var/lib/apt/lists,ro \
@@ -336,7 +336,7 @@ RUN --mount=type=cache,from=apt-base,source=/etc/apt,target=/etc/apt,ro \
 ## Devcontainer
 ##
 
-FROM docker.io/library/debian:bullseye as devcontainer
+FROM docker.io/library/debian:bookworm as devcontainer
 RUN --mount=type=cache,from=apt-base,source=/etc/apt,target=/etc/apt,ro \
     --mount=type=cache,from=apt-base,source=/var/cache/apt,target=/var/cache/apt \
     --mount=type=cache,from=apt-base,source=/var/lib/apt/lists,target=/var/lib/apt/lists,ro \
@@ -351,7 +351,7 @@ RUN --mount=type=cache,from=apt-base,source=/etc/apt,target=/etc/apt,ro \
         libssl-dev \
         locales \
         lsb-release \
-        netcat \
+        netcat-openbsd \
         pkg-config \
         skopeo \
         sudo \
@@ -371,7 +371,7 @@ RUN groupadd --gid=1000 code \
 RUN --mount=type=cache,from=apt-base,source=/etc/apt,target=/etc/apt,ro \
     --mount=type=cache,from=apt-base,source=/var/cache/apt,target=/var/cache/apt \
     --mount=type=cache,from=apt-base,source=/var/lib/apt/lists,target=/var/lib/apt/lists,ro \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -t bullseye-backports git
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -t bookworm-backports git
 
 RUN --mount=type=cache,from=apt-llvm,source=/etc/apt,target=/etc/apt,ro \
     --mount=type=cache,from=apt-llvm,source=/var/cache/apt,target=/var/cache/apt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN mkdir -p /etc/apt/keyrings && scurl https://deb.nodesource.com/gpgkey/nodeso
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install nodejs -y
 
+# At the moment, we can use the LLVM version shipped by Debian bookworm. If we
+# need to diverge in the future we can update this layer to use an alternate apt
+# source. See https://apt.llvm.org/.
 FROM apt-base as apt-llvm
 # RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg2
 # RUN curl --tlsv1.2 -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key |apt-key add -

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ be set in a `.devcontainer.json` file. For example:
 ```jsonc
 {
     "name": "linkerd-dev",
-    "image": "ghcr.io/linkerd/dev:v41",
+    "image": "ghcr.io/linkerd/dev:v42",
     "extensions": [
         "DavidAnson.vscode-markdownlint",
         "golang.go",
@@ -93,7 +93,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v41
+      - uses: linkerd/dev/actions/setup-tools@v42
       - uses: actions/checkout@v3
       - run: just-sh lint
       - run: just-dev lint-actions
@@ -112,7 +112,7 @@ building via docker.
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v41-go
+    container: ghcr.io/linkerd/dev:v42-go
     steps:
       - uses: actions/checkout@v3
       - run: go mod download
@@ -137,9 +137,9 @@ jobs:
           - v1.26
     steps:
       # Install just* tooling and Go linters
-      - uses: linkerd/dev/actions/setup-tools@v41
+      - uses: linkerd/dev/actions/setup-tools@v42
       # Configure the default Go toolchain
-      - uses: linkerd/dev/actions/setup-go@v41
+      - uses: linkerd/dev/actions/setup-go@v42
       - uses: actions/checkout@v3
       - run: just-k3d K3S_CHANNEL=${{ matrix.k8s }} create
       - run: go mod download
@@ -161,7 +161,7 @@ These containers can be used in a workflow like so:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v41-rust
+    container: ghcr.io/linkerd/dev:v42-rust
     steps:
       - uses: actions/checkout@v3
       - run: just-cargo fetch
@@ -175,7 +175,7 @@ Or, to build a static binary:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v41-rust-musl
+    container: ghcr.io/linkerd/dev:v42-rust-musl
     steps:
       - uses: actions/checkout@v3
       - run: just-cargo fetch
@@ -203,9 +203,9 @@ jobs:
       K3S_CHANNEL: ${{ matrix.k8s }}
     steps:
       # Install just* tooling
-      - uses: linkerd/dev/actions/setup-tools@v41
+      - uses: linkerd/dev/actions/setup-tools@v42
       # Configure the default Rust toolchain
-      - uses: linkerd/dev/actions/setup-rust@v41
+      - uses: linkerd/dev/actions/setup-rust@v42
       - run: just-k3d create
       - run: just-cargo fetch
       - run: just-cargo test-build

--- a/actions/setup-go/action.yml
+++ b/actions/setup-go/action.yml
@@ -5,7 +5,7 @@ inputs:
   # TODO(ver): CI should validate at this version matches that in the Dockerfile
   version:
     description: Go version
-    default: 1.19
+    default: 1.21
 
 runs:
   using: composite

--- a/actions/setup-rust/action.yml
+++ b/actions/setup-rust/action.yml
@@ -6,7 +6,7 @@ inputs:
   # TODO(ver): CI should validate at this version matches that in the Dockerfile
   version:
     description: Container image version
-    default: 1.64.0
+    default: 1.73.0
 
   components:
     description: Rust components to install

--- a/k3s-images.json
+++ b/k3s-images.json
@@ -1,26 +1,27 @@
 {
   "name": "docker.io/rancher/k3s",
   "channels": {
-    "stable": "v1.26.4-k3s1",
-    "latest": "v1.27.2-k3s1",
+    "stable": "v1.27.7-k3s1",
+    "latest": "v1.28.3-k3s1",
     "v1.20": "v1.20.15-k3s1",
     "v1.21": "v1.21.14-k3s1",
     "v1.22": "v1.22.17-k3s1",
     "v1.23": "v1.23.17-k3s1",
-    "v1.24": "v1.24.14-k3s1",
-    "v1.25": "v1.25.10-k3s1",
-    "v1.26": "v1.26.5-k3s1",
-    "v1.27": "v1.27.2-k3s1"
+    "v1.24": "v1.24.17-k3s1",
+    "v1.25": "v1.25.15-k3s1",
+    "v1.26": "v1.26.10-k3s1",
+    "v1.27": "v1.27.7-k3s1",
+    "v1.28": "v1.28.3-k3s1"
   },
   "digests": {
     "v1.20.15-k3s1": "sha256:0e49b63b8ee234e308ff578682f8f4f2f95bffda7ba75077e5da29548cd2a6b3",
     "v1.21.14-k3s1": "sha256:85745e4fa94050ead9c8a935c2a2136bfdfe107c3592fb229fb6aff26640ca72",
     "v1.22.17-k3s1": "sha256:c35db9bc45a073607f821343d94104ac2d9ca0ef85892b80fce21dd89583fb14",
     "v1.23.17-k3s1": "sha256:6f2b6d6d756b3f2f04c864ca2773435b9f19473a3568893720aef46f2cd47606",
-    "v1.24.14-k3s1": "sha256:2835a8194b85198bdc10e9172920f19f2f1b0b3f81dca8c4ffc85e84f49db470",
-    "v1.25.10-k3s1": "sha256:fbb83e55b0b7933d5e26869aacc35460d778f0ed0a479560023184dc4ef83ff7",
-    "v1.26.4-k3s1": "sha256:ff61834317d7f0a58e3366546fe301b7e6802a36c39126de686d9eb9e64f81cf",
-    "v1.26.5-k3s1": "sha256:ac34a7e8a2811639abc5c2aec9f918dcab1d0d9a2ed6a031e016591dc5d6df25",
-    "v1.27.2-k3s1": "sha256:66d13a1d6f92c7aa41f7734d5e97526a868484071d7467feb69dd868ad653254"
+    "v1.24.17-k3s1": "sha256:9e034931999854c6210b86a0708fde66b91370459fa077a4f9d008e7f51fc51d",
+    "v1.25.15-k3s1": "sha256:eacb00c298c91b2a84542fd52d5ef2ff5f12c7dfb8b8db8ab79d5f545c1515a1",
+    "v1.26.10-k3s1": "sha256:be33ac01f341e67990f273dfefee1794b9ed426e437904e949dc675d5f44420c",
+    "v1.27.7-k3s1": "sha256:7fb787b75f2839ad4e100facddcb1ce015609d8aec4201dcf2c01713518c9a9a",
+    "v1.28.3-k3s1": "sha256:7cf31ec93c58d5542cfd63649aea5a638203924dd9dc8c75bd7b1e91214bb4dd"
   }
 }


### PR DESCRIPTION
* Update Debian to bookworm
* Update Go to v1.21.3
* Update Rust to v1.73.0
* Update K3d to v5.6.0
* Update Node to v1.20
* Update markdownlint-cli2 to v0.10.0
* Update golangci-lint to v1.55.1
* Update k3s image metadata to include k3s v1.28