### PR TITLE
v43

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "linkerd-dev",
-    "image": "ghcr.io/linkerd/dev:v42",
+    "image": "ghcr.io/linkerd/dev:v43",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/Dockerfile
+++ b/Dockerfile
@@ -179,7 +179,7 @@ RUN url="https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-$
 # cargo-tarpaulin is a code coverage tool.
 FROM apt-base as cargo-tarpaulin
 ARG CARGO_TARPAULIN_VERSION=0.27.3
-RUN url="https://github.com/xd009642/tarpaulin/releases/download/${CARGO_TARPAULIN_VERSION}/cargo-tarpaulin-${CARGO_TARPAULIN_VERSION}-travis.tar.gz" ; \
+RUN url="https://github.com/xd009642/tarpaulin/releases/download/${CARGO_TARPAULIN_VERSION}/cargo-tarpaulin-x86_64-unknown-linux-musl.tar.gz" ;\
     scurl "$url" | tar xzvf - -C /usr/local/bin cargo-tarpaulin
 
 FROM scratch as tools-rust

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN url="https://github.com/olix0r/j5j/releases/download/${J5J_VERSION}/j5j-${J5
 
 # just runs build/test recipes. Like `make` but a bit more ergonomic.
 FROM apt-base as just
-ARG JUST_VERSION=1.13.0
+ARG JUST_VERSION=1.24.0
 RUN url="https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz" ; \
     scurl "$url" | tar zvxf - -C /usr/local/bin just
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ COPY --link --from=step /usr/bin/step-cli /bin/
 
 # actionlint lints github actions workflows.
 FROM apt-base as actionlint
-ARG ACTIONLINT_VERSION=v1.6.21
+ARG ACTIONLINT_VERSION=v1.6.26
 RUN url="https://github.com/rhysd/actionlint/releases/download/${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION#v}_linux_amd64.tar.gz" ; \
     scurl "$url" | tar xzvf - -C /usr/local/bin actionlint
 
@@ -128,23 +128,15 @@ RUN url="https://raw.githubusercontent.com/slimm609/checksec.sh/${CHECKSEC_VERSI
 
 # shellcheck lints shell scripts.
 FROM apt-base as shellcheck
-ARG SHELLCHECK_VERSION=v0.8.0
+ARG SHELLCHECK_VERSION=v0.9.0
 RUN url="https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" ; \
     scurl "$url" | tar xJvf - --strip-components=1 -C /usr/local/bin "shellcheck-${SHELLCHECK_VERSION}/shellcheck"
 COPY --link bin/just-sh /usr/local/bin/
-
-# taplo lints and formats toml files.
-FROM apt-base as taplo
-ARG TAPLO_VERSION=v0.8.0
-RUN url="https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION#v}/taplo-linux-x86_64.gz" ; \
-    scurl "$url" | gunzip >/usr/local/bin/taplo \
-    && chmod 755 /usr/local/bin/taplo
 
 FROM scratch as tools-lint
 COPY --link --from=actionlint /usr/local/bin/actionlint /bin/
 COPY --link --from=checksec /usr/local/bin/checksec /bin/
 COPY --link --from=shellcheck /usr/local/bin/shellcheck /bin/
-COPY --link --from=taplo /usr/local/bin/taplo /bin/
 COPY --link bin/action-* bin/just-dev bin/just-sh /bin/
 
 ##
@@ -174,19 +166,19 @@ RUN url="https://github.com/olix0r/cargo-action-fmt/releases/download/release%2F
 
 # cargo-deny checks cargo dependencies for licensing and RUSTSEC security issues.
 FROM apt-base as cargo-deny
-ARG CARGO_DENY_VERSION=0.12.2
+ARG CARGO_DENY_VERSION=0.14.11
 RUN url="https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz" ; \
     scurl "$url" | tar zvxf - --strip-components=1 -C /usr/local/bin "cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl/cargo-deny"
 
 # cargo-nextest is a nicer test runner.
 FROM apt-base as cargo-nextest
-ARG NEXTEST_VERSION=0.9.42
+ARG NEXTEST_VERSION=0.9.67
 RUN url="https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${NEXTEST_VERSION}/cargo-nextest-${NEXTEST_VERSION}-x86_64-unknown-linux-gnu.tar.gz" ; \
     scurl "$url" | tar zvxf - -C /usr/local/bin cargo-nextest
 
 # cargo-tarpaulin is a code coverage tool.
 FROM apt-base as cargo-tarpaulin
-ARG CARGO_TARPAULIN_VERSION=0.22.0
+ARG CARGO_TARPAULIN_VERSION=0.27.3
 RUN url="https://github.com/xd009642/tarpaulin/releases/download/${CARGO_TARPAULIN_VERSION}/cargo-tarpaulin-${CARGO_TARPAULIN_VERSION}-travis.tar.gz" ; \
     scurl "$url" | tar xzvf - -C /usr/local/bin cargo-tarpaulin
 
@@ -201,38 +193,38 @@ COPY --link bin/just-cargo /bin/
 ## Go tools
 ##
 
-FROM docker.io/library/golang:1.21.3 as go-delve
+FROM docker.io/library/golang:1.22 as go-delve
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
-FROM docker.io/library/golang:1.21.3 as go-impl
+FROM docker.io/library/golang:1.22 as go-impl
 RUN go install github.com/josharian/impl@latest
 
-FROM docker.io/library/golang:1.21.3 as go-outline
+FROM docker.io/library/golang:1.22 as go-outline
 RUN go install github.com/ramya-rao-a/go-outline@latest
 
-FROM docker.io/library/golang:1.21.3 as go-protoc
+FROM docker.io/library/golang:1.22 as go-protoc
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 
-FROM docker.io/library/golang:1.21.3 as golangci-lint
+FROM docker.io/library/golang:1.22 as golangci-lint
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
-FROM docker.io/library/golang:1.21.3 as gomodifytags
+FROM docker.io/library/golang:1.22 as gomodifytags
 RUN go install github.com/fatih/gomodifytags@latest
 
-FROM docker.io/library/golang:1.21.3 as gopkgs
+FROM docker.io/library/golang:1.22 as gopkgs
 RUN go install github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest
 
-FROM docker.io/library/golang:1.21.3 as goplay
+FROM docker.io/library/golang:1.22 as goplay
 RUN go install github.com/haya14busa/goplay/cmd/goplay@latest
 
-FROM docker.io/library/golang:1.21.3 as gopls
+FROM docker.io/library/golang:1.22 as gopls
 RUN go install golang.org/x/tools/gopls@latest
 
-FROM docker.io/library/golang:1.21.3 as gotests
+FROM docker.io/library/golang:1.22 as gotests
 RUN go install github.com/cweill/gotests/gotests@latest
 
-FROM docker.io/library/golang:1.21.3 as gotestsum
+FROM docker.io/library/golang:1.22 as gotestsum
 RUN go install gotest.tools/gotestsum@v0.4.2
 
 FROM scratch as tools-go
@@ -271,7 +263,7 @@ COPY --link --from=tools-script /bin/* /bin/
 ##
 
 # A Go build environment.
-FROM docker.io/library/golang:1.21.3 as go
+FROM docker.io/library/golang:1.22 as go
 RUN --mount=type=cache,from=apt-base,source=/etc/apt,target=/etc/apt,ro \
     --mount=type=cache,from=apt-base,source=/var/cache/apt,target=/var/cache/apt \
     --mount=type=cache,from=apt-base,source=/var/lib/apt/lists,target=/var/lib/apt/lists,ro \
@@ -285,7 +277,7 @@ ENV PROTOC_NO_VENDOR=1 \
     PROTOC_INCLUDE=/usr/local/include
 
 # A Rust build environment.
-FROM docker.io/rust:1.73.0-slim-bookworm as rust
+FROM docker.io/rust:1.76-slim-bookworm as rust
 RUN --mount=type=cache,from=apt-base,source=/etc/apt,target=/etc/apt,ro \
     --mount=type=cache,from=apt-base,source=/var/cache/apt,target=/var/cache/apt \
     --mount=type=cache,from=apt-base,source=/var/lib/apt/lists,target=/var/lib/apt/lists,ro \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,20 +65,20 @@ COPY --link bin/scurl /bin/
 
 # helm templates kubernetes manifests.
 FROM apt-base as helm
-ARG HELM_VERSION=v3.11.3
+ARG HELM_VERSION=v3.14.1
 RUN url="https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" ; \
     scurl "$url" | tar xzvf - --strip-components=1 -C /usr/local/bin linux-amd64/helm
 
 
 # helm-docs generates documentation from helm charts.
 FROM apt-base as helm-docs
-ARG HELM_DOCS_VERSION=v1.11.0
+ARG HELM_DOCS_VERSION=v1.12.0
 RUN url="https://github.com/norwoodj/helm-docs/releases/download/$HELM_DOCS_VERSION/helm-docs_${HELM_DOCS_VERSION#v}_Linux_x86_64.tar.gz" ; \
     scurl "$url" | tar xzvf - -C /usr/local/bin helm-docs
 
 # kubectl controls kubernetes clusters.
 FROM apt-base as kubectl
-ARG KUBECTL_VERSION=v1.27.1
+ARG KUBECTL_VERSION=v1.29.2
 RUN url="https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" ; \
     scurl -o /usr/local/bin/kubectl "$url" && chmod +x /usr/local/bin/kubectl
 
@@ -96,7 +96,7 @@ COPY --link k3s-images.json "$K3S_IMAGES_JSON"
 
 # step is a tool for managing certificates.
 FROM apt-base as step
-ARG STEP_VERSION=v0.24.3
+ARG STEP_VERSION=v0.25.2
 RUN scurl -O "https://dl.step.sm/gh-release/cli/docs-cli-install/${STEP_VERSION}/step-cli_${STEP_VERSION#v}_amd64.deb" \
     && dpkg -i "step-cli_${STEP_VERSION#v}_amd64.deb" \
     && rm "step-cli_${STEP_VERSION#v}_amd64.deb"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ be set in a `.devcontainer.json` file. For example:
 ```jsonc
 {
     "name": "linkerd-dev",
-    "image": "ghcr.io/linkerd/dev:v42",
+    "image": "ghcr.io/linkerd/dev:v43",
     "extensions": [
         "DavidAnson.vscode-markdownlint",
         "golang.go",
@@ -93,7 +93,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v42
+      - uses: linkerd/dev/actions/setup-tools@v43
       - uses: actions/checkout@v3
       - run: just-sh lint
       - run: just-dev lint-actions
@@ -112,7 +112,7 @@ building via docker.
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v42-go
+    container: ghcr.io/linkerd/dev:v43-go
     steps:
       - uses: actions/checkout@v3
       - run: go mod download
@@ -137,9 +137,9 @@ jobs:
           - v1.26
     steps:
       # Install just* tooling and Go linters
-      - uses: linkerd/dev/actions/setup-tools@v42
+      - uses: linkerd/dev/actions/setup-tools@v43
       # Configure the default Go toolchain
-      - uses: linkerd/dev/actions/setup-go@v42
+      - uses: linkerd/dev/actions/setup-go@v43
       - uses: actions/checkout@v3
       - run: just-k3d K3S_CHANNEL=${{ matrix.k8s }} create
       - run: go mod download
@@ -161,7 +161,7 @@ These containers can be used in a workflow like so:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v42-rust
+    container: ghcr.io/linkerd/dev:v43-rust
     steps:
       - uses: actions/checkout@v3
       - run: just-cargo fetch
@@ -175,7 +175,7 @@ Or, to build a static binary:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v42-rust-musl
+    container: ghcr.io/linkerd/dev:v43-rust-musl
     steps:
       - uses: actions/checkout@v3
       - run: just-cargo fetch
@@ -203,9 +203,9 @@ jobs:
       K3S_CHANNEL: ${{ matrix.k8s }}
     steps:
       # Install just* tooling
-      - uses: linkerd/dev/actions/setup-tools@v42
+      - uses: linkerd/dev/actions/setup-tools@v43
       # Configure the default Rust toolchain
-      - uses: linkerd/dev/actions/setup-rust@v42
+      - uses: linkerd/dev/actions/setup-rust@v43
       - run: just-k3d create
       - run: just-cargo fetch
       - run: just-cargo test-build

--- a/actions/setup-go/action.yml
+++ b/actions/setup-go/action.yml
@@ -5,11 +5,11 @@ inputs:
   # TODO(ver): CI should validate at this version matches that in the Dockerfile
   version:
     description: Go version
-    default: 1.21
+    default: 1.22
 
 runs:
   using: composite
   steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v5
       with:
         go-version: '${{ inputs.version }}'

--- a/actions/setup-rust/action.yml
+++ b/actions/setup-rust/action.yml
@@ -6,7 +6,7 @@ inputs:
   # TODO(ver): CI should validate at this version matches that in the Dockerfile
   version:
     description: Container image version
-    default: 1.73.0
+    default: 1.76.0
 
   components:
     description: Rust components to install

--- a/actions/setup-tools/action.yml
+++ b/actions/setup-tools/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: docker/setup-buildx-action@v2
+    - uses: docker/setup-buildx-action@v3
 
     - name: Extract tools
       shell: bash

--- a/k3s-images.json
+++ b/k3s-images.json
@@ -1,17 +1,18 @@
 {
   "name": "docker.io/rancher/k3s",
   "channels": {
-    "stable": "v1.27.7-k3s1",
-    "latest": "v1.28.3-k3s1",
+    "stable": "v1.28.6-k3s2",
+    "latest": "v1.29.1-k3s2",
     "v1.20": "v1.20.15-k3s1",
     "v1.21": "v1.21.14-k3s1",
     "v1.22": "v1.22.17-k3s1",
     "v1.23": "v1.23.17-k3s1",
     "v1.24": "v1.24.17-k3s1",
-    "v1.25": "v1.25.15-k3s1",
-    "v1.26": "v1.26.10-k3s1",
-    "v1.27": "v1.27.7-k3s1",
-    "v1.28": "v1.28.3-k3s1"
+    "v1.25": "v1.25.16-k3s4",
+    "v1.26": "v1.26.13-k3s2",
+    "v1.27": "v1.27.10-k3s2",
+    "v1.28": "v1.28.6-k3s2",
+    "v1.29": "v1.29.1-k3s2"
   },
   "digests": {
     "v1.20.15-k3s1": "sha256:0e49b63b8ee234e308ff578682f8f4f2f95bffda7ba75077e5da29548cd2a6b3",
@@ -19,9 +20,10 @@
     "v1.22.17-k3s1": "sha256:c35db9bc45a073607f821343d94104ac2d9ca0ef85892b80fce21dd89583fb14",
     "v1.23.17-k3s1": "sha256:6f2b6d6d756b3f2f04c864ca2773435b9f19473a3568893720aef46f2cd47606",
     "v1.24.17-k3s1": "sha256:9e034931999854c6210b86a0708fde66b91370459fa077a4f9d008e7f51fc51d",
-    "v1.25.15-k3s1": "sha256:eacb00c298c91b2a84542fd52d5ef2ff5f12c7dfb8b8db8ab79d5f545c1515a1",
-    "v1.26.10-k3s1": "sha256:be33ac01f341e67990f273dfefee1794b9ed426e437904e949dc675d5f44420c",
-    "v1.27.7-k3s1": "sha256:7fb787b75f2839ad4e100facddcb1ce015609d8aec4201dcf2c01713518c9a9a",
-    "v1.28.3-k3s1": "sha256:7cf31ec93c58d5542cfd63649aea5a638203924dd9dc8c75bd7b1e91214bb4dd"
+    "v1.25.16-k3s4": "sha256:b6e5bd6260e36da6c2f84de3d4f4cf636bab973a428149d9962e566bed7dc5cf",
+    "v1.26.13-k3s2": "sha256:19009a12bd34282298c85931aa0ffbf23db2d031bb522fbf4e9803b7e44d773a",
+    "v1.27.10-k3s2": "sha256:39cf130bafeb5472607b9f876500b0cc3e03e623bc298fef959d2bfd3eec4d2e",
+    "v1.28.6-k3s2": "sha256:6b47ec6de901f81f5f361b615dd60a438372b295d73df6966b1482de1704153c",
+    "v1.29.1-k3s2": "sha256:16ef2c025ff314906316b38fa84ce2ed81705432ef4c2cdf79790405365d4086"
   }
 }


### PR DESCRIPTION
## Go v1.22
* Go tooling updated to latest

## Rust v1.76
* cargo-deny v0.14.11
* cargo-nextest v0.9.67
* cargo-tarpaulin v0.27.3

## tools
* helm v3.11.3
* helm-docs v1.11.0
* just 1.24.0
* kubectl v1.29.2
* step-cli v0.25.2
* actionlint v1.6.26
* shellcheck v0.9.0
* taplo removed