### PR TITLE
feat(build): arm64 support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,11 +31,11 @@
   },
   "init": true,
   "runArgs": [
+    // Use the host network so we can access k3d, etc.
+    "--net=host",
     // Limit container memory usage.
     "--memory=12g",
-    "--memory-swap=12g",
-    // Use the host network so we can access k3d, etc.
-    "--net=host"
+    "--memory-swap=12g"
   ],
   "overrideCommand": false,
   "remoteUser": "code",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,46 +1,49 @@
 {
-    "name": "linkerd-dev",
-    "image": "ghcr.io/linkerd/dev:v43",
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "DavidAnson.vscode-markdownlint",
-                // "golang.go",
-                "kokakiwi.vscode-just",
-                // "ms-kubernetes-tools.vscode-kubernetes-tools",
-                "NathanRidley.autotrim",
-                //"rust-lang.rust-analyzer",
-                "samverschueren.final-newline",
-                "tamasfe.even-better-toml"
-                // "zxh404.vscode-proto3"
-            ],
-            "settings": {
-                "files.associations": {
-                    "just-*": "just"
-                }
-            },
+  "name": "linkerd-dev",
+  "image": "ghcr.io/linkerd/dev:v43",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false,
+      "installDockerBuildx": true,
+      "dockerDashComposeVersion": "v2",
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "DavidAnson.vscode-markdownlint",
+        // "golang.go",
+        "kokakiwi.vscode-just",
+        // "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "NathanRidley.autotrim",
+        //"rust-lang.rust-analyzer",
+        "samverschueren.final-newline",
+        "tamasfe.even-better-toml"
+        // "zxh404.vscode-proto3"
+      ],
+      "settings": {
+        "files.associations": {
+          "just-*": "just"
         }
-    },
-    "init": true,
-    "runArgs": [
-        // Limit container memory usage.
-        "--memory=12g",
-        "--memory-swap=12g",
-        // Use the host network so we can access k3d, etc.
-        "--net=host"
-    ],
-    "overrideCommand": false,
-    "remoteUser": "code",
-    "mounts": [
-        {
-            "source": "/var/run/docker.sock",
-            "target": "/var/run/docker-host.sock",
-            "type": "bind"
-        },
-        {
-            "source": "${localEnv:HOME}/.docker",
-            "target": "/home/code/.docker",
-            "type": "bind"
-        }
-    ]
+      },
+    }
+  },
+  "init": true,
+  "runArgs": [
+    // Limit container memory usage.
+    "--memory=12g",
+    "--memory-swap=12g",
+    // Use the host network so we can access k3d, etc.
+    "--net=host"
+  ],
+  "overrideCommand": false,
+  "remoteUser": "code",
+  "mounts": [
+    {
+      "source": "${localEnv:HOME}/.docker",
+      "target": "/home/code/.docker",
+      "type": "bind"
+    }
+  ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@
 # should not be published. Instead, these layers should be used to provide
 # cached data to individual `RUN` commands.
 
-FROM docker.io/library/debian:bookworm-slim as apt-base
-RUN echo 'deb https://deb.debian.org/debian bookworm-backports main' >>/etc/apt/sources.list
+FROM docker.io/library/debian:bookworm-backports as apt-base
 RUN DEBIAN_FRONTEND=noninteractive apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip xz-utils
 COPY --link bin/scurl /usr/local/bin/
@@ -332,7 +331,7 @@ RUN --mount=type=cache,from=apt-base,source=/etc/apt,target=/etc/apt,ro \
 ## Devcontainer
 ##
 
-FROM docker.io/library/debian:bookworm as devcontainer
+FROM docker.io/library/debian:bookworm-backports as devcontainer
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
@@ -397,13 +396,13 @@ RUN --mount=type=cache,id=apt-docker,from=apt-base,source=/etc/apt,target=/etc/a
     --mount=type=cache,id=apt-docker,from=apt-base,source=/var/cache/apt,target=/var/cache/apt \
     --mount=type=cache,id=apt-docker,from=apt-base,source=/var/lib/apt/lists,target=/var/lib/apt/lists \
     --mount=type=bind,from=tools,source=/bin/scurl,target=/usr/local/bin/scurl \
-    if [[ echo "${INSTALL_DOCKER}" | grep -qiE "^(true|yes|1)$" ]]; then \
+    if echo "${INSTALL_DOCKER}" | grep -qiE "^(true|yes|1)$"; then \
         # prevent pip from tanking the build on arm64 targets \
         if [[ "$(uname -m)" == "aarch64" ]]; then \
             apt-get install -y pipx docker-compose; \
         fi; \
         scurl https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/docker-debian.sh  | bash -s ; \
-    else; \
+    else \
         echo "SKIPPING DOCKER CLI INSTALL"; \
     fi
 

--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 version := ''
 image := 'ghcr.io/linkerd/dev'
+platform := 'linux/amd64,linux/arm64'
 _tag :=  if version != '' { "--tag=" + image + ':' + version } else { "" }
 
 k3s-image := 'docker.io/rancher/k3s'
@@ -27,6 +28,7 @@ build: && _list-if-load
         just output='{{ output }}' \
              image='{{ image }}' \
              version='{{ version }}' \
+             platform='{{ platform }}' \
             _target "$tgt"
     done
 
@@ -37,6 +39,7 @@ _list-if-load:
         just image='{{ image }}' \
              targets='{{ targets }}' \
              version='{{ version }}' \
+             platform='{{ platform }}' \
              list
      fi
 
@@ -91,12 +94,14 @@ _target target='':
     @just \
         output='{{ output }}' \
         image='{{ image }}' \
+        platform='{{ platform }}' \
         _build --target='{{ target }}' \
             {{ if version == '' { '' } else { '--tag=' + image + ':' + version + if target == 'devcontainer' { '' } else { '-' + target } } }}
 
 # Build the devcontainer image
 _build *args='':
     docker buildx build . {{ _tag }} --pull \
+        --platform='{{ platform }}' \
         --progress='{{ DOCKER_PROGRESS }}' \
         --output='{{ output }}' \
         {{ args }}

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ export DOCKER_PROGRESS := env_var_or_default('DOCKER_PROGRESS', 'auto')
 
 all: sync-k3s-images build
 
-build: && _list-if-load
+build *build_args='': && _list-if-load
     #!/usr/bin/env bash
     set -euo pipefail
     for tgt in {{ targets }} ; do
@@ -29,7 +29,7 @@ build: && _list-if-load
              image='{{ image }}' \
              version='{{ version }}' \
              platform='{{ platform }}' \
-            _target "$tgt"
+            _target "$tgt" {{ build_args }}
     done
 
 _list-if-load:
@@ -90,13 +90,14 @@ _k3s-channels:
                 | {key:.id, value:$tag}
             ] | from_entries'
 
-_target target='':
+_target target='' *args='':
     @just \
         output='{{ output }}' \
         image='{{ image }}' \
         platform='{{ platform }}' \
         _build --target='{{ target }}' \
-            {{ if version == '' { '' } else { '--tag=' + image + ':' + version + if target == 'devcontainer' { '' } else { '-' + target } } }}
+            {{ if version == '' { '' } else { '--tag=' + image + ':' + version + if target == 'devcontainer' { '' } else { '-' + target } } }} \
+            {{ args }}
 
 # Build the devcontainer image
 _build *args='':


### PR DESCRIPTION
PR adds multi-arch / arm64 support to the linkerd dev tooling stack.

----

### Notes

There are a few stages that _should_ be `FROM apt-base as {stage name}` but have been changed to `FROM docker.io/library/rust:alpine as {stage name}` (effectively). This is because the upstream sources these stages are pulling binaries from do not supply `arm64` binaries. Luckily though, they're all rust codebases, so `cargo install --git='repo url' --tag='existing version tag argument'` takes care of the issue as a simple proof of concept.

The repositories in question are:

- [j5j](https://github.com/olix0r/j5j/)
- [hokay](https://github.com/olix0r/hokay/)
- [cargo-action-fmt](https://github.com/olix0r/cargo-action-fmt/)
- ~~[cargo-deny](https://github.com/EmbarkStudios/cargo-deny/)~~

~~There is an open (but as-of-yet-unmerged) [PR](https://github.com/EmbarkStudios/cargo-deny/pull/659) to add `arm64` builds to `cargo-deny`'s releases.~~ <br/>[PR #659](https://github.com/EmbarkStudios/cargo-deny/pull/659) to `cargo-deny` was merged 2024-05-03. 

The other three repos (`j5j`, `hokay`, and `cargo-action-fmt`) all belong to @olix0r and so _hopefully_ won't be as much of an ordeal to add `arm64` support to 😅.

> **IMPORTANT:** _while this PR_ **_should_** _be entirely safe to merge without the altered stages being restored to their original_ `FROM apt-base as {stage name}` _forms, they do impose a non-zero but realistically negligible amount of overhead to build times. If the decision is made to have the three repos mentioned above supply multi-arch binaries of their own, the only real changes to the Dockerfile that should persist_ **_should_** _be the additions of the `sed` expressions that take care of formatting upstream urls to match the platform of the build target._

### Screenshots

![multi-arch-tags](https://github.com/linkerd/dev/assets/61921871/34b71d91-81db-48cc-9ce8-e26b55b260ac)
