### PR TITLE
fix(sync-k3s-images): skip updating on inconsistent release state

### DIFF
--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -22,7 +22,8 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y skopeo
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
       - uses: ./actions/setup-tools
-      - run: just sync-k3s-images
+      # The sync may fail when a new K3s version is released. This is expected.
+      - run: just sync-k3s-images || true
       - run: git diff --exit-code
 
   k3s-matrix:


### PR DESCRIPTION
The k3s release index may be updated before container images are available to use. This change updates the sync-k3s-images recipe to fail if any release images cannot be found. The CI workflow is updated to allow failures. The workflow fails if the sync recipe modifies the cached image digests.