### PR TITLE
feat!(ci): Remove arm/v7 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -339,18 +339,14 @@ COPY --link --from=just /usr/local/bin/just /usr/local/bin/
 FROM rust as rust-musl
 RUN rustup target add \
         aarch64-unknown-linux-musl \
-        armv7-unknown-linux-musleabihf \
         x86_64-unknown-linux-musl
 RUN --mount=type=cache,from=apt-base,source=/etc/apt,target=/etc/apt,ro \
     --mount=type=cache,from=apt-base,source=/var/cache/apt,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,from=apt-base,source=/var/lib/apt/lists,target=/var/lib/apt/lists,sharing=locked \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         g++-aarch64-linux-gnu \
-        g++-arm-linux-gnueabihf \
         gcc-aarch64-linux-gnu \
-        gcc-arm-linux-gnueabihf \
-        libc6-dev-arm64-cross \
-        libc6-dev-armhf-cross
+        libc6-dev-arm64-cross
 
 ##
 ## Devcontainer
@@ -383,7 +379,6 @@ RUN --mount=type=cache,from=apt-base,source=/etc/apt,target=/etc/apt,ro \
 # Link the gnu versions of ranlib to the musl toolchain.
 # See: https://github.com/linkerd/linkerd2/issues/13350
 RUN ln -s /usr/bin/aarch64-linux-gnu-ranlib /usr/bin/aarch64-linux-musl-ranlib && \
-    ln -s /usr/bin/arm-linux-gnueabihf-ranlib /usr/bin/arm-linux-musl-ranlib && \
     ln -s /usr/bin/x86_64-linux-gnu-ranlib /usr/bin/x86_64-linux-musl-ranlib
 
 RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ jobs:
 The `rust` container provides a Rust toolchain and associated utilities needed
 to build and test Rust code. The `rust-musl` container provides the same
 toolchain, but with the `musl` target installed with cross-compilation support
-for arm64 and armv7.
+for arm64.
 
 ### Rust in GitHub Actions
 

--- a/bin/just-cargo
+++ b/bin/just-cargo
@@ -20,8 +20,6 @@ _target := if target == '' {
 
 export RUSTFLAGS := env_var_or_default("RUSTFLAGS", "-D warnings") + if target == 'aarch64-unknown-linux-musl' {
         ' --codegen linker=aarch64-linux-gnu-gcc'
-    } else if target == 'armv7-unknown-linux-musleabihf' {
-        ' --codegen linker=arm-linux-gnueabihf-gcc'
     } else { '' }
 
 _llvm-version := '19'
@@ -45,20 +43,6 @@ export CC_aarch64_unknown_linux_musl := _clang
 export CFLAGS_aarch64_unknown_linux_musl := '--sysroot=/usr/aarch64-linux-gnu'
 export STRIP_aarch64_unknown_linux_musl := _strip
 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS := _rustflags-self-contained
-
-# linux/arm/v7 + gnueabihf
-export AR_armv7_unknown_linux_gnueabihf := _ar
-export CC_armv7_unknown_linux_gnueabihf := _clang
-export CFLAGS_armv7_unknown_linux_gnueabihf := '--sysroot=/usr/arm-linux-gnueabihf'
-export STRIP_armv7_unknown_linux_gnueabihf := _strip
-export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER := 'arm-linux-gnueabihf-gcc'
-
-# linux/arm/v7 + musl
-export AR_armv7_unknown_linux_musleabihf := _ar
-export CC_armv7_unknown_linux_musleabihf := _clang
-export CFLAGS_armv7_unknown_linux_musleabihf := '--sysroot=/usr/arm-linux-gnueabihf'
-export STRIP_armv7_unknown_linux_musleabihf := _strip
-export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_RUSTFLAGS := _rustflags-self-contained
 
 # linux/amd64 + gnu
 export AR_x86_64_unknown_linux_gnu := _ar


### PR DESCRIPTION
This architecture has become too significant of a maintenance burden, and isn't used often enough to justify the associated maintenance cost.

This removes arm/v7 from all the build infrastructure/dockerfiles/etc. Note that arm64 targets are still widely used and well supported.

Related: https://github.com/linkerd/linkerd2/pull/14308