### PR TITLE
fix: Setup devcontainers for building aws-lc-sys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -346,6 +346,7 @@ RUN --mount=type=cache,from=apt-base,source=/etc/apt,target=/etc/apt,ro \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         g++-aarch64-linux-gnu \
         gcc-aarch64-linux-gnu \
+        binutils-aarch64-linux-gnu \
         libc6-dev-arm64-cross
 
 ##

--- a/bin/just-cargo
+++ b/bin/just-cargo
@@ -33,16 +33,12 @@ _rustflags-self-contained := "-Clink-self-contained=yes -Clinker=rust-lld -Clink
 # linux/arm64 + gnu
 export AR_aarch64_unknown_linux_gnu := _ar
 export CC_aarch64_unknown_linux_gnu := _clang
-export CFLAGS_aarch64_unknown_linux_gnu := '--sysroot=/usr/aarch64-linux-gnu'
-export AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_gnu := '-fuse-ld=/usr/aarch64-linux-gnu/bin/ld'
 export STRIP_aarch64_unknown_linux_gnu := _strip
 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER := 'aarch64-linux-gnu-gcc'
 
 # linux/arm64 + musl
 export AR_aarch64_unknown_linux_musl := _ar
 export CC_aarch64_unknown_linux_musl := _clang
-export CFLAGS_aarch64_unknown_linux_musl := '--sysroot=/usr/aarch64-linux-gnu'
-export AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_musl := '-fuse-ld=/usr/aarch64-linux-gnu/bin/ld'
 export STRIP_aarch64_unknown_linux_musl := _strip
 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS := _rustflags-self-contained
 

--- a/bin/just-cargo
+++ b/bin/just-cargo
@@ -34,6 +34,7 @@ _rustflags-self-contained := "-Clink-self-contained=yes -Clinker=rust-lld -Clink
 export AR_aarch64_unknown_linux_gnu := _ar
 export CC_aarch64_unknown_linux_gnu := _clang
 export CFLAGS_aarch64_unknown_linux_gnu := '--sysroot=/usr/aarch64-linux-gnu'
+export AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_gnu := '-fuse-ld=/usr/aarch64-linux-gnu/bin/ld'
 export STRIP_aarch64_unknown_linux_gnu := _strip
 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER := 'aarch64-linux-gnu-gcc'
 
@@ -41,6 +42,7 @@ export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER := 'aarch64-linux-gnu-gcc'
 export AR_aarch64_unknown_linux_musl := _ar
 export CC_aarch64_unknown_linux_musl := _clang
 export CFLAGS_aarch64_unknown_linux_musl := '--sysroot=/usr/aarch64-linux-gnu'
+export AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_musl := '-fuse-ld=/usr/aarch64-linux-gnu/bin/ld'
 export STRIP_aarch64_unknown_linux_musl := _strip
 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS := _rustflags-self-contained
 


### PR DESCRIPTION
This needs a few environment variables and debian packages installed to facilitate building that package. This includes the env vars in the `just-cargo` invocation, and the packages in the rust, rust-musl, and devcontainer images.