### PR TITLE
feat(docs): add a `RELEASE.md` file

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+# `dev` Release
+
+Releases are performed via the GitHub GUI. Navigate to the repository in a
+web browsewr, at <https://github.com/linkerd/dev>.
+
+1. Navigate to the "Releases" tab, and select "Draft a new release".
+2. Select "tag", and create a new tag. Increment the version number from the
+previous release.
+3. Be sure that the release is targeting `main`.
+4. Click "Generate release notes", which will generate release notes using
+information from the changes since the last release.
+5. Click "Publish release".


### PR DESCRIPTION
the release process for this repository was not documented.

this commit introduces a small release runbook.

Signed-off-by: katelyn martin <git@katelyn.world>
