### PR TITLE
build: v50

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "linkerd-dev",
-    "image": "ghcr.io/linkerd/dev:v48",
+    "image": "ghcr.io/linkerd/dev:v50",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ##
 
 
-ARG GO_TAG=1.25
+ARG GO_TAG=1.26
 ARG RUST_TAG=1.90.0
 
 # These layers include Debian apt caches, so layers that extend `apt-base`
@@ -20,7 +20,7 @@ COPY --link bin/scurl /usr/local/bin/
 
 FROM apt-base as apt-node
 RUN apt-get install -y gnupg2
-ARG NODE_MAJOR=20
+ARG NODE_MAJOR=26
 RUN mkdir -p /etc/apt/keyrings && scurl https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install nodejs -y
@@ -45,13 +45,13 @@ RUN url="https://github.com/olix0r/j5j/releases/download/${J5J_VERSION}/j5j-${J5
 
 # just runs build/test recipes. Like `make` but a bit more ergonomic.
 FROM apt-base as just
-ARG JUST_VERSION=1.43.0 # repo=casey/just
+ARG JUST_VERSION=1.54.0 # repo=casey/just
 RUN url="https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz" ; \
     scurl "$url" | tar zvxf - -C /usr/local/bin just
 
 # yq is kind of like jq, but for YAML.
 FROM apt-base as yq
-ARG YQ_VERSION=v4.47.2 # repo=mikefarah/yq
+ARG YQ_VERSION=v4.53.3 # repo=mikefarah/yq
 RUN url="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" ; \
     scurl -o /yq "$url" && chmod +x /yq
 
@@ -67,7 +67,7 @@ COPY --link bin/scurl /bin/
 
 # helm templates kubernetes manifests.
 FROM apt-base as helm
-ARG HELM_VERSION=v3.19.0 # repo=helm/helm
+ARG HELM_VERSION=v3.21.2 # repo=helm/helm
 RUN url="https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" ; \
     scurl "$url" | tar xzvf - --strip-components=1 -C /usr/local/bin linux-amd64/helm
 
@@ -80,13 +80,13 @@ RUN url="https://github.com/norwoodj/helm-docs/releases/download/$HELM_DOCS_VERS
 
 # kubectl controls kubernetes clusters.
 FROM apt-base as kubectl
-ARG KUBECTL_VERSION=v1.34.1 # repo=kubernetes/kubernetes
+ARG KUBECTL_VERSION=v1.36.2 # repo=kubernetes/kubernetes
 RUN url="https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" ; \
     scurl -o /usr/local/bin/kubectl "$url" && chmod +x /usr/local/bin/kubectl
 
 # k3d runs kubernetes clusters in docker.
 FROM apt-base as k3d
-COPY --link --from=ghcr.io/k3d-io/k3d:5.8.3 /bin/k3d /usr/local/bin/
+COPY --link --from=ghcr.io/k3d-io/k3d:5.9.0 /bin/k3d /usr/local/bin/
 # just-k3d is a utility that encodes many of the common k3d commands we use.
 COPY --link bin/just-k3d /usr/local/bin/
 # `K3S_IMAGES_JSON` configures just-k3d so that it uses a pinned version of k3s.
@@ -115,7 +115,7 @@ COPY --link --from=ghcr.io/anchore/grype:v0.96.1 /grype /bin/
 
 # actionlint lints github actions workflows.
 FROM apt-base as actionlint
-ARG ACTIONLINT_VERSION=v1.7.7 # repo=rhysd/actionlint
+ARG ACTIONLINT_VERSION=v1.7.12 # repo=rhysd/actionlint
 RUN url="https://github.com/rhysd/actionlint/releases/download/${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION#v}_linux_amd64.tar.gz" ; \
     scurl "$url" | tar xzvf - -C /usr/local/bin actionlint
 
@@ -136,7 +136,7 @@ COPY --link bin/action-* bin/just-dev bin/just-sh /bin/
 ##
 
 FROM apt-base as protobuf
-ARG PROTOC_VERSION=v32.1 # repo=protocolbuffers/protobuf
+ARG PROTOC_VERSION=v35.1 # repo=protocolbuffers/protobuf
 RUN url="https://github.com/google/protobuf/releases/download/$PROTOC_VERSION/protoc-${PROTOC_VERSION#v}-linux-$(uname -m).zip" ; \
     cd $(mktemp -d) && \
     scurl -o protoc.zip  "$url" && \
@@ -157,25 +157,25 @@ RUN url="https://github.com/olix0r/cargo-action-fmt/releases/download/release%2F
     scurl "$url" | tar zvxf - -C /usr/local/bin cargo-action-fmt
 
 FROM apt-base as cargo-auditable
-ARG CARGO_AUDITABLE_VERSION=v0.6.6 # repo=rust-secure-code/cargo-auditable
+ARG CARGO_AUDITABLE_VERSION=v0.7.5 # repo=rust-secure-code/cargo-auditable
 RUN url="https://github.com/rust-secure-code/cargo-auditable/releases/download/${CARGO_AUDITABLE_VERSION}/cargo-auditable-x86_64-unknown-linux-gnu.tar.xz" ; \
     scurl "$url" | tar xJvf - --strip-components=1 -C /usr/local/bin cargo-auditable-x86_64-unknown-linux-gnu/cargo-auditable
 
 # cargo-deny checks cargo dependencies for licensing and RUSTSEC security issues.
 FROM apt-base as cargo-deny
-ARG CARGO_DENY_VERSION=0.18.9 # repo=EmbarkStudios/cargo-deny
+ARG CARGO_DENY_VERSION=0.19.9 # repo=EmbarkStudios/cargo-deny
 RUN url="https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz" ; \
     scurl "$url" | tar zvxf - --strip-components=1 -C /usr/local/bin "cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl/cargo-deny"
 
 # cargo-nextest is a nicer test runner.
 FROM apt-base as cargo-nextest
-ARG NEXTEST_VERSION=0.9.104 # repo=nextest-rs/nextest,prefix=cargo-nextest-
+ARG NEXTEST_VERSION=0.9.138 # repo=nextest-rs/nextest,prefix=cargo-nextest-
 RUN url="https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${NEXTEST_VERSION}/cargo-nextest-${NEXTEST_VERSION}-x86_64-unknown-linux-gnu.tar.gz" ; \
     scurl "$url" | tar zvxf - -C /usr/local/bin cargo-nextest
 
 # cargo-tarpaulin is a code coverage tool.
 FROM apt-base as cargo-tarpaulin
-ARG CARGO_TARPAULIN_VERSION=0.32.8 # repo=xd009642/tarpaulin
+ARG CARGO_TARPAULIN_VERSION=0.35.5 # repo=xd009642/tarpaulin
 RUN url="https://github.com/xd009642/tarpaulin/releases/download/${CARGO_TARPAULIN_VERSION}/cargo-tarpaulin-x86_64-unknown-linux-musl.tar.gz" ;\
     scurl "$url" | tar xzvf - -C /usr/local/bin cargo-tarpaulin
 
@@ -201,8 +201,8 @@ FROM docker.io/library/golang:${GO_TAG} as go-outline
 RUN go install github.com/ramya-rao-a/go-outline@latest
 
 FROM docker.io/library/golang:${GO_TAG} as go-protoc
-ARG PROTOC_GEN_GO_TAG=v1.35.2
-ARG PROTOC_GEN_GO_GRPC_VERSION=v1.5.1
+ARG PROTOC_GEN_GO_TAG=v1.36.11
+ARG PROTOC_GEN_GO_GRPC_VERSION=v1.6.2
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_TAG}
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}
 
@@ -243,7 +243,7 @@ COPY --link --from=gotestsum /go/bin/gotestsum /bin/
 
 # Networking utilities
 FROM scratch as tools-net
-COPY --link --from=ghcr.io/olix0r/hokay:v0.2.2 /hokay /bin/
+COPY --link --from=ghcr.io/olix0r/hokay:v0.2.3 /usr/local/bin/hokay /bin/
 
 ##
 ## All Tools
@@ -395,7 +395,7 @@ RUN --mount=type=cache,id=apt-docker,from=apt-base,source=/etc/apt,target=/etc/a
     scurl https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/docker-debian.sh | bash -s
 ENV DOCKER_BUILDKIT=1
 
-ARG MARKDOWNLINT_VERSION=0.15.0
+ARG MARKDOWNLINT_VERSION=0.22.1
 RUN --mount=type=cache,from=apt-node,source=/etc/apt,target=/etc/apt,ro \
     --mount=type=cache,from=apt-node,source=/var/cache/apt,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,from=apt-node,source=/var/lib/apt/lists,target=/var/lib/apt/lists,sharing=locked \

--- a/README.md
+++ b/README.md
@@ -231,3 +231,15 @@ Push all images:
 ```sh
 :; just push=true version=vNN build
 ```
+
+## Dev Container Package Permissions
+
+A minimal number of people have access to push new Linkerd dev containers.
+To modify the user with this permission, navigate to:
+
+```text
+linkerd > Packages > dev
+```
+
+and select `Package settings` in the right-hand navigation.  See the
+`Manage access` section.

--- a/actions/setup-go/action.yml
+++ b/actions/setup-go/action.yml
@@ -5,11 +5,11 @@ inputs:
   # TODO(ver): CI should validate at this version matches that in the Dockerfile
   version:
     description: Go version
-    default: 1.25
+    default: 1.26
 
 runs:
   using: composite
   steps:
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
       with:
         go-version: '${{ inputs.version }}'

--- a/actions/setup-tools/action.yml
+++ b/actions/setup-tools/action.yml
@@ -5,7 +5,7 @@ inputs:
   # TODO(ver): CI should validate at this version matches the most recent release tag
   version:
     description: Container image version
-    default: v48
+    default: v49
 
 runs:
   using: composite

--- a/actions/setup-tools/action.yml
+++ b/actions/setup-tools/action.yml
@@ -5,7 +5,7 @@ inputs:
   # TODO(ver): CI should validate at this version matches the most recent release tag
   version:
     description: Container image version
-    default: v49
+    default: v50
 
 runs:
   using: composite

--- a/justfile
+++ b/justfile
@@ -73,7 +73,7 @@ sync-k3s-images:
         | jq . > k3s-images.json
     jq . k3s-images.json
 
-minimum-k8s := '20'
+minimum-k8s := '31'
 
 update-versions:
     go run ./update-versions.go --in-place

--- a/k3s-images.json
+++ b/k3s-images.json
@@ -1,41 +1,21 @@
 {
   "name": "docker.io/rancher/k3s",
   "channels": {
-    "stable": "v1.34.4-k3s1",
-    "latest": "v1.35.1-k3s1",
-    "v1.20": "v1.20.15-k3s1",
-    "v1.21": "v1.21.14-k3s1",
-    "v1.22": "v1.22.17-k3s1",
-    "v1.23": "v1.23.17-k3s1",
-    "v1.24": "v1.24.17-k3s1",
-    "v1.25": "v1.25.16-k3s4",
-    "v1.26": "v1.26.15-k3s1",
-    "v1.27": "v1.27.16-k3s1",
-    "v1.28": "v1.28.15-k3s1",
-    "v1.29": "v1.29.15-k3s1",
-    "v1.30": "v1.30.14-k3s2",
+    "stable": "v1.36.2-k3s1",
+    "latest": "v1.36.2-k3s1",
     "v1.31": "v1.31.14-k3s1",
-    "v1.32": "v1.32.12-k3s1",
-    "v1.33": "v1.33.8-k3s1",
-    "v1.34": "v1.34.4-k3s1",
-    "v1.35": "v1.35.1-k3s1"
+    "v1.32": "v1.32.13-k3s1",
+    "v1.33": "v1.33.13-k3s1",
+    "v1.34": "v1.34.9-k3s1",
+    "v1.35": "v1.35.6-k3s1",
+    "v1.36": "v1.36.2-k3s1"
   },
   "digests": {
-    "v1.20.15-k3s1": "sha256:0e49b63b8ee234e308ff578682f8f4f2f95bffda7ba75077e5da29548cd2a6b3",
-    "v1.21.14-k3s1": "sha256:85745e4fa94050ead9c8a935c2a2136bfdfe107c3592fb229fb6aff26640ca72",
-    "v1.22.17-k3s1": "sha256:c35db9bc45a073607f821343d94104ac2d9ca0ef85892b80fce21dd89583fb14",
-    "v1.23.17-k3s1": "sha256:6f2b6d6d756b3f2f04c864ca2773435b9f19473a3568893720aef46f2cd47606",
-    "v1.24.17-k3s1": "sha256:9e034931999854c6210b86a0708fde66b91370459fa077a4f9d008e7f51fc51d",
-    "v1.25.16-k3s4": "sha256:b6e5bd6260e36da6c2f84de3d4f4cf636bab973a428149d9962e566bed7dc5cf",
-    "v1.26.15-k3s1": "sha256:fabb4a57b34c67c0dfab602bd6ae54b34598a9f9218004089d1202431088fdb1",
-    "v1.27.16-k3s1": "sha256:b7bca8255da9e25a9fdd95bae61f99f8cd424d90691fc5125621b2955bebdfd2",
-    "v1.28.15-k3s1": "sha256:af4f882a4cfaf418cb03d52c59cd150f42bf2b72f084c4592c6a133f4856660d",
-    "v1.29.15-k3s1": "sha256:8f782bd47a41509e89c1ad1d60b02998cc5b0f1310a36c65aa0f331cde866c80",
-    "v1.30.14-k3s2": "sha256:5f02ba89b28861574b1677d91943b57f55f5fe0b451d539f83e650c8925fd9a2",
     "v1.31.14-k3s1": "sha256:6c33f6a8ff6dd6ae63428d5c8e331e059a4111d5ec3f5beaa9df6c50ba6b7ce8",
-    "v1.32.12-k3s1": "sha256:9941a1f9f3f04a4b11da20e5a9b68f45199daf1f27b7b95c57c0d138d88196fb",
-    "v1.33.8-k3s1": "sha256:10dfeb707c3f2bb477ca6f925ed2bf8fed0c2fdf38d53da81b364e9fc92dc7aa",
-    "v1.34.4-k3s1": "sha256:a5f627f1ed014dede348fdc77bc7e452d03712a8daff000e0f2667d28f9a2d11",
-    "v1.35.1-k3s1": "sha256:634920385dc89133d80060b3a3b2b547e734d711ef8c050e6b5c6341800d53fd"
+    "v1.32.13-k3s1": "sha256:7534b63e02277917f77c584ed5532b31562c760d6bb8fe88059002e9bdeee033",
+    "v1.33.13-k3s1": "sha256:523cfdf26aaef2c3164eefa30a61f5f1dca86d1cf3f1d38beae62ac65905a3ab",
+    "v1.34.9-k3s1": "sha256:9c162556657a38e394d1f944081388ae7c0b85ec29134c509583083e287f804e",
+    "v1.35.6-k3s1": "sha256:9d6b9c15e8031c1aea7dd7f0cdc019f5e74a23c53b9eada564b7a8dc94efc14c",
+    "v1.36.2-k3s1": "sha256:6a47cea22c4b834d4ba72c89d291696b79ebe406251f90b446e4dff03513dd87"
   }
 }


### PR DESCRIPTION
Ran `just sync-k3s-images` and `just update-versions`. Then:

In Dockerfile:

- `RUST_TAG` was reverted back to `1.90.0`; that should be incremented separately in concert with the other reports
- helm was manually bumped to `v3.21.2`; not jumpting straight into v4 just yet
- bumped NODE to v26 in Dockerfile
- bumped k3d to 5.9.0
- bumped PROTOC_GEN_GO_TAG to v1.36.11
- bumped PROTOC_GEN_GO_GRPC_VERSION to v1.6.2
- bumped hokay to v0.2.3
- bumped MARKDOWNLINT_VERSION to 0.22.1

in justfile:
- set `minimum-k8s` to 31

In setup-go/action.yml:
- bumped go to 1.26 